### PR TITLE
Add a timeout argument and increase default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.0] - 2016-06-02
+### Added
+  - Option to set the timeout. Default to 5000 ms.
+
 ## 2.0.3 - 2016-05-18
 ### Fixed
   - Fix again destination path.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const ncp = require('ncp').ncp;
 commander
   .option('-p, --pattern <regexp>', 'Regexp used to parse the lists on stdin (ex: "^lib\/([^\/]+).*\/([^\/]+)$"')
   .option('-d, --dest <string>', 'String that owns pattern matches (ex: /path/to/img/$1/$2')
+  .option('-t, --timeout <number>', 'Timeout to wait for data until the process exits', 5000)
   .parse(process.argv);
 
 /* Main */
@@ -27,7 +28,7 @@ const timeID = setTimeout(() => {
   process.stdout.write('No data received from stdin!');
   commander.help();
   process.exit(1);
-}, 2000);
+}, commander.timeout);
 
 var dataStdin = '';
 process.stdin.on('data', (data) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ls-to-cp",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Copy files to a destination path computed from a regexp.",
   "bin": {
     "ls-to-cp": "index.js"


### PR DESCRIPTION
The default timeout to wait for data before exiting is a bit too short.

See also cr0cK/rev-data#2.
